### PR TITLE
Add OpenRouter-based VER evaluator for closed-source LLMs

### DIFF
--- a/projects/vrt_sa2va/eval_openrouter/common.py
+++ b/projects/vrt_sa2va/eval_openrouter/common.py
@@ -1,0 +1,491 @@
+"""
+Shared helpers for the VER evaluation pipeline.
+
+Used by both `eval_openrouter.py` (API-driven evaluation) and
+`eval_qwen.py` (local Qwen-VL HuggingFace evaluation):
+
+  * mask ↔ bbox helpers, IoU + Hungarian-matching scorers
+  * Gemini-style box-format parsing (configurable order/normalisation)
+  * SAM2 wrapper that turns a list of pred boxes into binary masks
+  * per-class aggregation + LaTeX-row formatting + console summary
+  * tiny .env loader and PIL→base64 utility
+
+Anything backend-specific (prompt wording, HTTP client, HF model loader,
+batched generation loop) lives in the per-backend script.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+from io import BytesIO
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from PIL import Image
+from pycocotools import mask as mask_utils
+from scipy.optimize import linear_sum_assignment
+
+
+# ────────────────────────── env / .env loader ────────────────────────────
+
+def load_env_from_file(env_path: str) -> None:
+    """Lightweight .env loader (avoids pulling python-dotenv as a hard dep)."""
+    if not os.path.isfile(env_path):
+        return
+    with open(env_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            key = key.strip()
+            val = val.strip().strip('"').strip("'")
+            if key and key not in os.environ:
+                os.environ[key] = val
+
+
+# ─────────────────────── PIL ↔ base64 (HTTP payload) ─────────────────────
+
+def encode_pil_to_base64(image: Image.Image, fmt: str = "JPEG") -> str:
+    buf = BytesIO()
+    img = image.convert("RGB") if image.mode != "RGB" else image
+    img.save(buf, format=fmt, quality=92)
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+# ─────────────────────── mask ↔ bbox helpers ─────────────────────────────
+
+def mask_to_bbox(mask: np.ndarray) -> List[int]:
+    """Binary HxW mask → tight [xmin, ymin, xmax, ymax] (0-box for empty mask)."""
+    if mask.sum() == 0:
+        return [0, 0, 0, 0]
+    rows = np.any(mask, axis=1)
+    cols = np.any(mask, axis=0)
+    if not rows.any() or not cols.any():
+        return [0, 0, 0, 0]
+    ymin, ymax = np.where(rows)[0][[0, -1]]
+    xmin, xmax = np.where(cols)[0][[0, -1]]
+    return [int(xmin), int(ymin), int(xmax), int(ymax)]
+
+
+def bbox_iou(a: List[int], b: List[int]) -> float:
+    xA, yA = max(a[0], b[0]), max(a[1], b[1])
+    xB, yB = min(a[2], b[2]), min(a[3], b[3])
+    inter = max(0, xB - xA) * max(0, yB - yA)
+    area_a = max(0, a[2] - a[0]) * max(0, a[3] - a[1])
+    area_b = max(0, b[2] - b[0]) * max(0, b[3] - b[1])
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0
+
+
+def calculate_miou_bbox(pred_boxes: List[List[int]], gt_boxes: List[List[int]]) -> List[float]:
+    """Hungarian-match pred boxes to GT boxes; per-GT IoU (0 if unmatched)."""
+    if not gt_boxes:
+        return []
+    if not pred_boxes:
+        return [0.0] * len(gt_boxes)
+    iou = np.zeros((len(pred_boxes), len(gt_boxes)), dtype=np.float32)
+    for i, pb in enumerate(pred_boxes):
+        for j, gb in enumerate(gt_boxes):
+            iou[i, j] = bbox_iou(list(pb), list(gb))
+    row_ind, col_ind = linear_sum_assignment(1 - iou)
+    out = np.zeros(len(gt_boxes), dtype=np.float32)
+    out[col_ind] = iou[row_ind, col_ind]
+    return out.tolist()
+
+
+def calculate_miou_mask(pred_masks: List[np.ndarray], gt_masks: List[np.ndarray]) -> List[float]:
+    """Hungarian-match predicted masks to GT masks; per-GT IoU (0 if unmatched)."""
+    if not gt_masks:
+        return []
+    if not pred_masks:
+        return [0.0] * len(gt_masks)
+
+    pm = np.stack([m.astype(bool) for m in pred_masks])
+    gm = np.stack([m.astype(bool) for m in gt_masks])
+    inter = np.logical_and(pm[:, None], gm[None, :]).sum(axis=(2, 3)).astype(np.float32)
+    union = np.logical_or(pm[:, None], gm[None, :]).sum(axis=(2, 3)).astype(np.float32)
+    iou = np.zeros_like(inter)
+    np.divide(inter, union, out=iou, where=union > 0)
+
+    row_ind, col_ind = linear_sum_assignment(1 - iou)
+    out = np.zeros(len(gt_masks), dtype=np.float32)
+    out[col_ind] = iou[row_ind, col_ind]
+    return out.tolist()
+
+
+def encode_mask_rle(mask: np.ndarray) -> Dict:
+    """Binary HxW mask → COCO RLE (counts as utf-8 string for JSON)."""
+    rle = mask_utils.encode(np.asfortranarray(mask.astype(np.uint8)))
+    rle["counts"] = rle["counts"].decode("utf-8")
+    return rle
+
+
+def decode_mask_rle(rle: Dict) -> np.ndarray:
+    return mask_utils.decode(rle).astype(bool)
+
+
+# ─────────────────── prediction parsing (configurable) ───────────────────
+
+# Supported box conventions:
+#   yxyx_norm1000 — [ymin, xmin, ymax, xmax] normalised 0-1000 (Gemini default)
+#   xyxy_norm1000 — [x1, y1, x2, y2]         normalised 0-1000 (Qwen instructed)
+#   xyxy_pixel    — [x1, y1, x2, y2]         raw pixel        (Qwen native fallback)
+BOX_FORMATS = ("yxyx_norm1000", "xyxy_norm1000", "xyxy_pixel")
+
+_BBOX_PATTERN = re.compile(r"\[([\d\s,.\-]+)\]")
+
+
+def auto_box_format_for_model(model_id: str) -> str:
+    """Pick a sensible default convention based on the model family."""
+    m = model_id.lower()
+    if m.startswith("google/") or "gemini" in m:
+        return "yxyx_norm1000"
+    if m.startswith("qwen/") or "qwen" in m:
+        return "xyxy_norm1000"
+    return "yxyx_norm1000"
+
+
+def extract_bboxes_from_text(text: str, width: int, height: int,
+                             box_format: str = "yxyx_norm1000") -> List[List[int]]:
+    """
+    Parse every `[a, b, c, d]` group in `text` according to `box_format`,
+    returning pixel `[xmin, ymin, xmax, ymax]` boxes.
+
+    Robustness shortcuts:
+      * 0-1 normalisation auto-rescaled to 0-1000 (some models do this).
+      * For *_norm1000 formats: if values clearly exceed 1000, fall back to
+        pixel interpretation (Qwen sometimes ignores normalise instructions).
+      * Degenerate / empty boxes dropped.
+    """
+    if box_format not in BOX_FORMATS:
+        raise ValueError(f"Unknown box_format {box_format!r}; expected one of {BOX_FORMATS}")
+
+    bboxes: List[List[int]] = []
+    for match in _BBOX_PATTERN.findall(text):
+        try:
+            coords = [float(c.strip()) for c in match.split(",")]
+        except ValueError:
+            continue
+        if len(coords) != 4:
+            continue
+        a, b, c, d = coords
+        max_val = max(a, b, c, d)
+
+        if max_val <= 1.5 and box_format != "xyxy_pixel":
+            a, b, c, d = (v * 1000 for v in (a, b, c, d))
+            max_val = max(a, b, c, d)
+
+        if box_format == "yxyx_norm1000":
+            ymin_n, xmin_n, ymax_n, xmax_n = a, b, c, d
+            xmin = int(round(xmin_n / 1000 * width))
+            ymin = int(round(ymin_n / 1000 * height))
+            xmax = int(round(xmax_n / 1000 * width))
+            ymax = int(round(ymax_n / 1000 * height))
+        elif box_format == "xyxy_norm1000":
+            if max_val > 1000.0 and (a < width * 1.1 and c < width * 1.1
+                                     and b < height * 1.1 and d < height * 1.1):
+                xmin, ymin, xmax, ymax = int(a), int(b), int(c), int(d)
+            else:
+                x1_n, y1_n, x2_n, y2_n = a, b, c, d
+                xmin = int(round(x1_n / 1000 * width))
+                ymin = int(round(y1_n / 1000 * height))
+                xmax = int(round(x2_n / 1000 * width))
+                ymax = int(round(y2_n / 1000 * height))
+        else:  # xyxy_pixel
+            xmin, ymin, xmax, ymax = int(a), int(b), int(c), int(d)
+
+        xmin = max(0, min(xmin, width - 1))
+        ymin = max(0, min(ymin, height - 1))
+        xmax = max(0, min(xmax, width))
+        ymax = max(0, min(ymax, height))
+        if xmax <= xmin or ymax <= ymin:
+            continue
+        bboxes.append([xmin, ymin, xmax, ymax])
+    return bboxes
+
+
+def separate_bboxes_by_section(text: str, width: int, height: int,
+                               box_format: str = "yxyx_norm1000"
+                               ) -> Tuple[List[List[int]], List[List[int]]]:
+    """Split predicted boxes into reasoning (`<think>`) vs answer (`<answer>`) buckets."""
+    answer_match = re.search(r"<answer>(.*?)</answer>", text, re.DOTALL)
+    if answer_match:
+        reasoning_text = text[: answer_match.start()]
+        answer_text = answer_match.group(1)
+    elif "<think>" in text and "</think>" in text:
+        reasoning_text = text.split("</think>")[0]
+        answer_text = text.split("</think>")[-1]
+    elif "```json" in text:
+        reasoning_text = text.split("```json")[0]
+        answer_text = text.split("```json", 1)[-1]
+    else:
+        reasoning_text, answer_text = text, text
+
+    r_boxes = extract_bboxes_from_text(reasoning_text, width, height, box_format)
+    a_boxes = extract_bboxes_from_text(answer_text, width, height, box_format)
+    r_boxes = [list(b) for b in {tuple(b) for b in r_boxes}]
+    a_boxes = [list(b) for b in {tuple(b) for b in a_boxes}]
+    return r_boxes, a_boxes
+
+
+# ────────────────────────── per-sample record ────────────────────────────
+
+def build_record(sample: Dict, pred_text: str, box_format: str) -> Dict:
+    """
+    Build a Phase-1 record from a packed VRT sample + raw model response.
+
+    The record carries:
+      * sample_info        — key, question, class_ids, image dims
+      * ground_truth       — GT obj ids, tight GT bboxes, GT masks (RLE)
+      * prediction         — raw text, parsed pred bboxes (mask RLEs filled
+                             in later by `score_with_sam2`)
+      * evaluation_bbox    — bbox-vs-bbox mIoU (always available after parse)
+      * evaluation         — mask-vs-mask mIoU (filled by `score_with_sam2`)
+    """
+    image: Image.Image = sample["image"]
+    objects_info: Dict[int, Dict] = sample.get("objects_info", {})
+    gt_r_ids: List[int] = list(sample.get("human_labeled_r_objs", []))
+    gt_a_ids: List[int] = list(sample.get("human_labeled_a_objs", []))
+
+    gt_r_masks_np = [objects_info[i]["mask"] for i in gt_r_ids if i in objects_info]
+    gt_a_masks_np = [objects_info[i]["mask"] for i in gt_a_ids if i in objects_info]
+    gt_r_boxes = [mask_to_bbox(m) for m in gt_r_masks_np]
+    gt_a_boxes = [mask_to_bbox(m) for m in gt_a_masks_np]
+    gt_r_masks_rle = [encode_mask_rle(m) for m in gt_r_masks_np]
+    gt_a_masks_rle = [encode_mask_rle(m) for m in gt_a_masks_np]
+
+    pred_r_boxes, pred_a_boxes = separate_bboxes_by_section(
+        pred_text, image.width, image.height, box_format)
+    r_box_ious = calculate_miou_bbox(pred_r_boxes, gt_r_boxes)
+    a_box_ious = calculate_miou_bbox(pred_a_boxes, gt_a_boxes)
+
+    return {
+        "sample_info": {
+            "key": sample["key"],
+            "question": sample["question"],
+            "class_ids": list(sample.get("class_ids", [])),
+            "image_size": [image.width, image.height],
+        },
+        "ground_truth": {
+            "reasoning_obj_ids": gt_r_ids,
+            "answer_obj_ids": gt_a_ids,
+            "reasoning_bboxes": gt_r_boxes,
+            "answer_bboxes": gt_a_boxes,
+            "reasoning_masks_rle": gt_r_masks_rle,
+            "answer_masks_rle": gt_a_masks_rle,
+        },
+        "prediction": {
+            "text": pred_text,
+            "reasoning_bboxes": pred_r_boxes,
+            "answer_bboxes": pred_a_boxes,
+            "reasoning_masks_rle": [],
+            "answer_masks_rle": [],
+        },
+        "evaluation_bbox": {
+            "reasoning_ious": r_box_ious,
+            "answer_ious": a_box_ious,
+            "reasoning_miou": float(np.mean(r_box_ious)) if r_box_ious else 0.0,
+            "answer_miou": float(np.mean(a_box_ious)) if a_box_ious else 0.0,
+        },
+        "evaluation": {
+            "reasoning_ious": [],
+            "answer_ious": [],
+            "reasoning_miou": 0.0,
+            "answer_miou": 0.0,
+        },
+    }
+
+
+# ────────────────────────────── SAM2 ─────────────────────────────────────
+
+class SAM2BoxToMask:
+    """Wraps SAM2ImagePredictor — set_image once per sample, predict once per box.
+    Returns one binary HxW mask per input box."""
+
+    def __init__(self, checkpoint: str, config: str, device: Optional[str] = None):
+        import torch
+        from third_parts.sam2.build_sam import build_sam2
+        from third_parts.sam2.sam2_image_predictor import SAM2ImagePredictor
+
+        device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        print(f"[sam2] loading {checkpoint} on {device}")
+        sam2_model = build_sam2(config, checkpoint, device=torch.device(device))
+        self.predictor = SAM2ImagePredictor(sam2_model)
+
+        if device.startswith("cuda"):
+            torch.autocast("cuda", dtype=torch.bfloat16).__enter__()
+            if torch.cuda.get_device_properties(0).major >= 8:
+                torch.backends.cuda.matmul.allow_tf32 = True
+                torch.backends.cudnn.allow_tf32 = True
+        print("[sam2] ready")
+
+    def boxes_to_masks(self, image_np: np.ndarray, boxes: List[List[int]]) -> List[np.ndarray]:
+        if not boxes:
+            return []
+        self.predictor.set_image(image_np)
+        out: List[np.ndarray] = []
+        for box in boxes:
+            masks, _scores, _ = self.predictor.predict(
+                point_coords=None, point_labels=None,
+                box=np.asarray(box, dtype=np.float32),
+                multimask_output=False,
+            )
+            out.append(np.asarray(masks[0]).astype(bool))
+        return out
+
+
+def score_with_sam2(record: Dict, dataset, sam2: SAM2BoxToMask) -> Dict:
+    """Phase-2 in-place augmentation: SAM2 the predicted boxes, score
+    against GT masks. Modifies and returns `record`."""
+    sample = dataset.get_sample(record["sample_info"]["key"])
+    if sample is None:
+        return record
+
+    image_np = np.array(sample["image"].convert("RGB"))
+    pred_r = sam2.boxes_to_masks(image_np, record["prediction"]["reasoning_bboxes"])
+    pred_a = sam2.boxes_to_masks(image_np, record["prediction"]["answer_bboxes"])
+    record["prediction"]["reasoning_masks_rle"] = [encode_mask_rle(m) for m in pred_r]
+    record["prediction"]["answer_masks_rle"] = [encode_mask_rle(m) for m in pred_a]
+
+    gt_r = [decode_mask_rle(r) for r in record["ground_truth"]["reasoning_masks_rle"]]
+    gt_a = [decode_mask_rle(r) for r in record["ground_truth"]["answer_masks_rle"]]
+    r_ious = calculate_miou_mask(pred_r, gt_r)
+    a_ious = calculate_miou_mask(pred_a, gt_a)
+    record["evaluation"]["reasoning_ious"] = r_ious
+    record["evaluation"]["answer_ious"] = a_ious
+    record["evaluation"]["reasoning_miou"] = float(np.mean(r_ious)) if r_ious else 0.0
+    record["evaluation"]["answer_miou"] = float(np.mean(a_ious)) if a_ious else 0.0
+    return record
+
+
+# ───────────── per-class aggregation (table-ready output) ───────────────
+
+# Matches the LaTeX table column order in the paper.
+TABLE_CLASSES: List[str] = ["#comp", "#func", "#loc", "#visf"]
+
+
+def _lq_sq(ious: List[float]) -> Tuple[float, float, float]:
+    """(mIoU, LQ, SQ): mIoU = mean; LQ = hit-rate at IoU>0.5; SQ = mean among hits."""
+    if not ious:
+        return 0.0, 0.0, 0.0
+    arr = np.asarray(ious, dtype=np.float32)
+    miou = float(arr.mean())
+    hits = arr > 0.5
+    lq = float(hits.sum() / len(arr))
+    sq = float(arr[hits].mean()) if hits.any() else 0.0
+    return miou, lq, sq
+
+
+def _aggregate_one_metric(results: List[Dict], eval_key: str) -> Dict:
+    """Per-class + overall mIoU/LQ/SQ for a single eval namespace
+    ('evaluation' for masks, 'evaluation_bbox' for boxes)."""
+    buckets: Dict[str, Dict[str, List[float]]] = {
+        c: {"r": [], "a": []} for c in TABLE_CLASSES
+    }
+    buckets["overall"] = {"r": [], "a": []}
+
+    for r in results:
+        ev = r.get(eval_key, {})
+        r_ious = ev.get("reasoning_ious", [])
+        a_ious = ev.get("answer_ious", [])
+        cls_ids = r["sample_info"].get("class_ids", [])
+        for c in list(cls_ids) + ["overall"]:
+            if c not in buckets:
+                continue
+            buckets[c]["r"].extend(r_ious)
+            buckets[c]["a"].extend(a_ious)
+
+    out: Dict[str, Dict] = {}
+    for c, b in buckets.items():
+        r_miou, r_lq, r_sq = _lq_sq(b["r"])
+        a_miou, a_lq, a_sq = _lq_sq(b["a"])
+        out[c] = {
+            "reasoning_miou": r_miou, "reasoning_lq": r_lq, "reasoning_sq": r_sq,
+            "answer_miou": a_miou, "answer_lq": a_lq, "answer_sq": a_sq,
+            "n_reasoning": len(b["r"]), "n_answer": len(b["a"]),
+        }
+    return out
+
+
+def aggregate_metrics(results: List[Dict], model_label: str = "model") -> Dict:
+    """
+    Returns a summary dict with both the flat overall-mask `metrics` field
+    (kept for backward compatibility with earlier consumers) and per-class
+    breakdowns for both box and mask versions, plus LaTeX-ready row strings
+    labelled with `model_label`.
+    """
+    mask_breakdown = _aggregate_one_metric(results, "evaluation")
+    bbox_breakdown = _aggregate_one_metric(results, "evaluation_bbox")
+    overall_mask = mask_breakdown["overall"]
+
+    return {
+        "metrics": {
+            "reasoning_miou": overall_mask["reasoning_miou"],
+            "reasoning_lq": overall_mask["reasoning_lq"],
+            "reasoning_sq": overall_mask["reasoning_sq"],
+            "answer_miou": overall_mask["answer_miou"],
+            "answer_lq": overall_mask["answer_lq"],
+            "answer_sq": overall_mask["answer_sq"],
+        },
+        "total_reasoning_masks_evaluated": overall_mask["n_reasoning"],
+        "total_answer_masks_evaluated": overall_mask["n_answer"],
+        "per_class_breakdown": {
+            "bbox": bbox_breakdown,
+            "mask": mask_breakdown,
+        },
+        "latex_rows": _build_latex_rows(model_label, bbox_breakdown, mask_breakdown),
+    }
+
+
+def _build_latex_rows(model_label: str, bbox_b: Dict, mask_b: Dict) -> Dict[str, str]:
+    """Format the four #cls + Overall triplet (VRQ-C, VRQ-G, mIoU) into a
+    LaTeX-ready row for each metric kind. VRQ-C ≡ reasoning_lq,
+    VRQ-G ≡ reasoning_sq, mIoU ≡ answer_miou — matches the paper table."""
+    def _row(label: str, br: Dict) -> str:
+        cells = [label]
+        for c in TABLE_CLASSES + ["overall"]:
+            m = br.get(c, {})
+            cells.append(
+                f"{m.get('reasoning_lq', 0.0) * 100:.1f} & "
+                f"{m.get('reasoning_sq', 0.0) * 100:.1f} & "
+                f"{m.get('answer_miou', 0.0) * 100:.1f}"
+            )
+        return " & ".join(cells) + r" \\"
+    return {
+        "bbox": _row(f"{model_label} (box)", bbox_b),
+        "mask": _row(f"{model_label} + SAM2", mask_b),
+    }
+
+
+def _print_breakdown(title: str, breakdown: Dict) -> None:
+    print(f"\n{title}")
+    print(f"  {'class':>8s}  {'VRQ-C':>6s}  {'VRQ-G':>6s}  {'mIoU':>6s}  (n_R / n_A)")
+    for c in TABLE_CLASSES + ["overall"]:
+        m = breakdown.get(c, {})
+        print(f"  {c:>8s}  {m.get('reasoning_lq', 0)*100:>6.1f}  "
+              f"{m.get('reasoning_sq', 0)*100:>6.1f}  "
+              f"{m.get('answer_miou', 0)*100:>6.1f}  "
+              f"({m.get('n_reasoning', 0)} / {m.get('n_answer', 0)})")
+
+
+def print_summary(summary: Dict) -> None:
+    print("\n=== VER Eval Summary ===")
+    print(f"Model: {summary.get('model')}")
+    print(f"Total samples: {summary['total_samples']}")
+    print(f"R masks: {summary['total_reasoning_masks_evaluated']}, "
+          f"A masks: {summary['total_answer_masks_evaluated']}")
+
+    pcb = summary.get("per_class_breakdown", {})
+    if "bbox" in pcb:
+        _print_breakdown("Box-vs-box (no SAM2):", pcb["bbox"])
+    if "mask" in pcb:
+        _print_breakdown("Mask-vs-mask (SAM2 on preds, human masks on GT):", pcb["mask"])
+
+    rows = summary.get("latex_rows", {})
+    if rows:
+        print("\nLaTeX rows (VRQ-C & VRQ-G & mIoU per class, then overall):")
+        for v in rows.values():
+            print(f"  {v}")

--- a/projects/vrt_sa2va/eval_openrouter/eval_openrouter.py
+++ b/projects/vrt_sa2va/eval_openrouter/eval_openrouter.py
@@ -1,0 +1,368 @@
+"""
+VER mask evaluation via OpenRouter (Gemini, GPT, OpenRouter-hosted Qwen, etc.).
+
+Pipeline
+--------
+1. Inference phase (parallel HTTP via OpenRouter) — for each sample, prompt the
+   model with the strict VER prompt and parse out bounding boxes.
+2. SAM2 phase (sequential, GPU) — feed each predicted box into SAM2 to obtain
+   a binary mask.
+3. Scoring — Hungarian-match predicted *masks* against the human-labelled GT
+   masks shipped with the packed dataset (SAM2 is NOT involved on the GT side)
+   and compute mIoU / LQ / SQ for both reasoning and answer sections.
+
+Usage
+-----
+    # 1. Put OPENROUTER_API_KEY=sk-or-... in <project_root>/.env
+    # 2. Run:
+    PYTHONPATH=. uv run --extra latest python \\
+        projects/vrt_sa2va/eval_openrouter/eval_openrouter.py \\
+        --output_dir workspace/eval_results/openrouter_gemini_3.1_pro_full \\
+        --model google/gemini-3.1-pro-preview --workers 8 --visualize
+
+Concurrency
+-----------
+`--workers N` issues N requests in parallel (OpenRouter rate-limits per model;
+4-8 is usually safe). The SAM2 phase runs sequentially on a single GPU.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict, List, Optional
+
+import tqdm
+from PIL import Image
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from projects.vrt_sa2va.evaluation.packed_vrt_eval_dataloader import PackedVRTEvalDataset
+from projects.vrt_sa2va.eval_openrouter.common import (
+    BOX_FORMATS,
+    SAM2BoxToMask,
+    aggregate_metrics,
+    auto_box_format_for_model,
+    build_record,
+    encode_pil_to_base64,
+    load_env_from_file,
+    print_summary,
+    score_with_sam2,
+)
+
+
+# ───────────────────────── strict VER prompt ─────────────────────────────
+
+# Prompt design notes:
+#
+# The VER benchmark labels two distinct object sets per sample:
+#   * reasoning evidence — every object referenced while reasoning to the
+#     answer (typically 2–4 per sample; scored by `reasoning_miou`)
+#   * answer objects — only the object(s) that directly answer the question
+#     (typically 1; scored by `answer_miou`)
+#
+# We map the training tag convention (<ver>...</ver> for evidence,
+# <vea>...</vea> for the answer) to box output: box after every evidence
+# reference inside <think>, box only after the answer object(s) inside
+# <answer>. The instructions below make this split explicit, since otherwise
+# vision LLMs tend to (a) only emit the answer's box and forget evidence,
+# (b) duplicate every <think> box into <answer>, or (c) wrap predictions in
+# an extra ```json``` block.
+
+_BOX_FORMAT_DESC = {
+    "yxyx_norm1000": (
+        "[ymin, xmin, ymax, xmax]",
+        "with each coordinate normalised to the range 0–1000 (integers)",
+        "[120, 45, 600, 400]",
+    ),
+    "xyxy_norm1000": (
+        "[x1, y1, x2, y2]",
+        "with each coordinate normalised to the range 0–1000 (integers)",
+        "[45, 120, 400, 600]",
+    ),
+    "xyxy_pixel": (
+        "[x1, y1, x2, y2]",
+        "in absolute pixel coordinates (integers)",
+        "[45, 120, 400, 600]",
+    ),
+}
+
+
+def _think_prompt(box_format: str) -> str:
+    fmt_label, fmt_norm_desc, ex = _BOX_FORMAT_DESC[box_format]
+    return (
+        "You will be shown an image together with a question that requires "
+        "reasoning over multiple visual objects.\n\n"
+        "Output two sections, in this order:\n"
+        f"1) <think>...</think> — a step-by-step reasoning trace. Every object "
+        f"you reference as visual evidence MUST be followed inline by its "
+        f"bounding box written as {fmt_label} {fmt_norm_desc}. "
+        "List ALL relevant evidence objects (usually 2–4), not only the answer.\n"
+        "2) <answer>...</answer> — a concise sentence that directly answers the "
+        "question. Include the bounding box ONLY for the object(s) that are the "
+        "direct answer (usually 1). Do NOT repeat the boxes of the supporting "
+        "evidence here.\n\n"
+        "Format:\n"
+        f"<think>...the boat {ex} is moored next to the bridge {ex}...</think>\n"
+        f"<answer>The boat {ex} is the answer.</answer>\n\n"
+        "Strict rules:\n"
+        f"- Use only the bracket format {fmt_label}; do NOT emit JSON code "
+        "blocks, markdown, or `box_2d`/`bbox_2d` keys.\n"
+        "- Do NOT write anything outside the <think> and <answer> tags.\n"
+        "- Output coordinates as integers.\n\n"
+        "Question: {question}"
+    )
+
+
+def _no_think_prompt(box_format: str) -> str:
+    fmt_label, fmt_norm_desc, _ = _BOX_FORMAT_DESC[box_format]
+    return (
+        "Look at the image and answer the question. Wrap the answer in "
+        "<answer> </answer> tags. For every object you mention as part of the "
+        f"answer, append its bounding box inline as {fmt_label} {fmt_norm_desc}. "
+        "Do not emit JSON code blocks or anything outside the <answer> tags.\n\n"
+        "Question: {question}"
+    )
+
+
+def build_prompt(question: str, use_thinking: bool, box_format: str = "yxyx_norm1000") -> str:
+    template = _think_prompt(box_format) if use_thinking else _no_think_prompt(box_format)
+    return template.format(question=question)
+
+
+# ───────────────────────── OpenRouter client ─────────────────────────────
+
+class OpenRouterClient:
+    """Thin wrapper around the OpenAI SDK pointed at OpenRouter."""
+
+    def __init__(self, api_key: str, model: str,
+                 base_url: str = "https://openrouter.ai/api/v1",
+                 referer: Optional[str] = None,
+                 site_title: Optional[str] = None,
+                 max_tokens: int = 4096,
+                 temperature: float = 0.0,
+                 timeout: float = 120.0):
+        import openai
+        self.model = model
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        extra_headers = {}
+        if referer:
+            extra_headers["HTTP-Referer"] = referer
+        if site_title:
+            extra_headers["X-Title"] = site_title
+        self._extra_headers = extra_headers or None
+        self.client = openai.OpenAI(api_key=api_key, base_url=base_url, timeout=timeout)
+
+    def query(self, image: Image.Image, prompt: str, max_retries: int = 4) -> str:
+        b64 = encode_pil_to_base64(image)
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {"type": "image_url",
+                 "image_url": {"url": f"data:image/jpeg;base64,{b64}"}},
+            ],
+        }]
+        last_err: Optional[Exception] = None
+        for attempt in range(max_retries):
+            try:
+                resp = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,
+                    max_tokens=self.max_tokens,
+                    temperature=self.temperature,
+                    extra_headers=self._extra_headers,
+                )
+                return resp.choices[0].message.content or ""
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+                wait = min(2 ** attempt, 30) + 0.5 * attempt
+                print(f"[openrouter] attempt {attempt + 1}/{max_retries} failed: {e!r} — sleeping {wait:.1f}s")
+                time.sleep(wait)
+        print(f"[openrouter] giving up after {max_retries} attempts: {last_err!r}")
+        return ""
+
+
+# ───────────────────────────── main ──────────────────────────────────────
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Evaluate any vision LLM on VER via OpenRouter.")
+    p.add_argument("--packed_tfrecord",
+                   default=os.path.join(PROJECT_ROOT, "data/VRT-Eval/vrt_eval.tfrecord"))
+    p.add_argument("--env_file", default=os.path.join(PROJECT_ROOT, ".env"))
+    p.add_argument("--model", default="google/gemini-2.5-pro",
+                   help="OpenRouter model id (e.g. google/gemini-3.1-pro-preview, "
+                        "qwen/qwen3-vl-8b-instruct, openai/gpt-5.4).")
+    p.add_argument("--base_url", default="https://openrouter.ai/api/v1")
+    p.add_argument("--output_dir", default="work_dirs/openrouter_eval")
+    p.add_argument("--max_samples", type=int, default=None)
+    p.add_argument("--workers", type=int, default=1)
+    p.add_argument("--max_tokens", type=int, default=4096)
+    p.add_argument("--temperature", type=float, default=0.0)
+    p.add_argument("--no-thinking", dest="use_thinking", action="store_false")
+    p.add_argument("--box_format", default=None, choices=list(BOX_FORMATS) + [None],
+                   help="Default: yxyx_norm1000 for google/*, xyxy_norm1000 for qwen/*.")
+    p.add_argument("--sleep", type=float, default=0.0)
+    p.add_argument("--referer", default="https://github.com/Sa2VA")
+    p.add_argument("--site_title", default="Sa2VA-VER-Eval")
+    p.add_argument("--resume", action="store_true")
+    p.add_argument("--visualize", action="store_true")
+    p.add_argument("--visualize-low-iou-only", action="store_true")
+    p.add_argument("--sam2_checkpoint",
+                   default=os.path.join(PROJECT_ROOT, "pretrained/sam2/sam2_hiera_large.pt"))
+    p.add_argument("--sam2_config", default="sam2_hiera_l.yaml")
+    p.add_argument("--sam2_device", default=None)
+    p.add_argument("--skip_sam2", action="store_true")
+    return p.parse_args()
+
+
+def predict_sample(sample: Dict, client: OpenRouterClient, use_thinking: bool,
+                   box_format: str) -> Dict:
+    """Phase-1: build strict prompt, query model, build record."""
+    prompt = build_prompt(sample["question"], use_thinking, box_format)
+    pred_text = client.query(sample["image"], prompt)
+    return build_record(sample, pred_text, box_format)
+
+
+def main():
+    args = parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    if args.box_format is None:
+        args.box_format = auto_box_format_for_model(args.model)
+    print(f"[cfg] model={args.model}  box_format={args.box_format}")
+
+    load_env_from_file(args.env_file)
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        sys.exit(
+            f"[error] OPENROUTER_API_KEY not found. Add it to {args.env_file} "
+            "or export it in the shell before running."
+        )
+
+    print(f"[data] loading packed eval tfrecord: {args.packed_tfrecord}")
+    dataset = PackedVRTEvalDataset(args.packed_tfrecord)
+    keys = sorted(dataset.get_all_keys())
+    if args.max_samples:
+        keys = keys[: args.max_samples]
+    print(f"[data] {len(keys)} samples to evaluate")
+
+    # Resume: accept the current or the older bbox-only filename.
+    results_path = os.path.join(args.output_dir, "ver_results.json")
+    summary_path = os.path.join(args.output_dir, "ver_summary.json")
+    older_path = os.path.join(args.output_dir, "ver_bbox_results.json")
+    done_keys: set = set()
+    existing_results: List[Dict] = []
+    if args.resume:
+        load_from = results_path if os.path.isfile(results_path) else (
+            older_path if os.path.isfile(older_path) else None)
+        if load_from:
+            try:
+                with open(load_from, "r") as f:
+                    existing_results = json.load(f)
+                done_keys = {r["sample_info"]["key"] for r in existing_results}
+                print(f"[resume] loaded {len(done_keys)} samples from {load_from}")
+            except Exception as e:  # noqa: BLE001
+                print(f"[resume] failed to load existing results, starting fresh: {e!r}")
+    pending_keys = [k for k in keys if k not in done_keys]
+
+    client = OpenRouterClient(
+        api_key=api_key, model=args.model, base_url=args.base_url,
+        referer=args.referer, site_title=args.site_title,
+        max_tokens=args.max_tokens, temperature=args.temperature,
+    )
+
+    # ── Phase 1: parallel HTTP inference ─────────────────────────────────
+    results: List[Dict] = list(existing_results)
+    write_lock = threading.Lock()
+
+    def _predict(key: str) -> Optional[Dict]:
+        sample = dataset.get_sample(key)
+        if not sample:
+            print(f"[warn] could not load sample {key}")
+            return None
+        try:
+            return predict_sample(sample, client, args.use_thinking, args.box_format)
+        except Exception as e:  # noqa: BLE001
+            print(f"[warn] sample {key} failed: {e!r}")
+            return None
+
+    def _checkpoint():
+        with open(results_path, "w") as f:
+            json.dump(results, f, indent=2)
+
+    if args.workers <= 1:
+        for key in tqdm.tqdm(pending_keys, desc="openrouter"):
+            res = _predict(key)
+            if res is not None:
+                results.append(res)
+                if len(results) % 10 == 0:
+                    with write_lock:
+                        _checkpoint()
+            if args.sleep > 0:
+                time.sleep(args.sleep)
+    else:
+        with ThreadPoolExecutor(max_workers=args.workers) as pool:
+            futures = {pool.submit(_predict, k): k for k in pending_keys}
+            for fut in tqdm.tqdm(as_completed(futures), total=len(futures), desc="openrouter"):
+                res = fut.result()
+                if res is not None:
+                    with write_lock:
+                        results.append(res)
+                        if len(results) % 10 == 0:
+                            _checkpoint()
+    _checkpoint()
+    print(f"[openrouter] phase complete: {len(results)} records → {results_path}")
+
+    # ── Phase 2: SAM2 → mask IoU (sequential GPU) ────────────────────────
+    if args.skip_sam2:
+        print("[sam2] skipped (--skip_sam2)")
+    else:
+        todo = [r for r in results
+                if not r["evaluation"]["reasoning_ious"]
+                and not r["evaluation"]["answer_ious"]
+                and (r["prediction"]["reasoning_bboxes"] or r["prediction"]["answer_bboxes"]
+                     or r["ground_truth"]["reasoning_masks_rle"]
+                     or r["ground_truth"]["answer_masks_rle"])]
+        if todo:
+            sam2 = SAM2BoxToMask(args.sam2_checkpoint, args.sam2_config, args.sam2_device)
+            for rec in tqdm.tqdm(todo, desc="sam2"):
+                try:
+                    score_with_sam2(rec, dataset, sam2)
+                except Exception as e:  # noqa: BLE001
+                    print(f"[warn] SAM2 failed for {rec['sample_info']['key']}: {e!r}")
+
+    _checkpoint()
+    print(f"[out] detailed results → {results_path}")
+
+    summary = aggregate_metrics(results, model_label=args.model)
+    summary.update({
+        "model": args.model,
+        "base_url": args.base_url,
+        "use_thinking": args.use_thinking,
+        "box_format": args.box_format,
+        "prompt_style": "strict",
+        "total_samples": len(results),
+        "detailed_results": results,
+    })
+    with open(summary_path, "w") as f:
+        json.dump(summary, f, indent=2)
+    print(f"[out] summary → {summary_path}")
+    print_summary(summary)
+
+    if args.visualize:
+        from projects.vrt_sa2va.eval_openrouter.visualize_results import visualize
+        visualize(args.output_dir, args.packed_tfrecord,
+                  low_iou_only=args.visualize_low_iou_only)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/vrt_sa2va/eval_openrouter/visualize_results.py
+++ b/projects/vrt_sa2va/eval_openrouter/visualize_results.py
@@ -1,0 +1,435 @@
+"""
+Visualise OpenRouter / Gemini + SAM2 VER eval results.
+
+Reads `<output_dir>/ver_results.json` (or the older `ver_bbox_results.json`)
+produced by `eval_openrouter.py` and the packed VRT eval tfrecord
+(for the original image + GT masks), then emits one PNG per sample into
+`<output_dir>/visualizations/`.
+
+Layout per sample (matplotlib):
+
+    ┌───────────────────────────┬──────────────────────────────────┐
+    │ Prediction (boxes only)   │ Ground Truth (masks only)        │
+    │  image with pred boxes    │  image with GT mask overlays     │
+    │  coloured green ≥0.5 IoU  │  (no boxes, no SAM2 — these are  │
+    │  red < 0.5 IoU            │  the human-labelled masks)       │
+    ├───────────────────────────┴──────────────────────────────────┤
+    │ <think> text (cleaned, with bbox literals highlighted)       │
+    │ <answer> text                                                │
+    └──────────────────────────────────────────────────────────────┘
+
+Usage
+-----
+    PYTHONPATH=. uv run --extra latest python \\
+        projects/vrt_sa2va/eval_openrouter/visualize_results.py \\
+        workspace/eval_results/openrouter_gemini_2.5_pro_smoke10
+
+Filtering
+---------
+By default visualises every sample. Pass `--low-iou-only` to skip samples
+whose mean IoU exceeds 0.5 (useful for cherry-picking failures).
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Dict, List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.patches import Rectangle
+from PIL import Image
+from pycocotools import mask as mask_utils
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from projects.vrt_sa2va.evaluation.packed_vrt_eval_dataloader import PackedVRTEvalDataset
+
+
+# ─────────────────────────── colour helpers ──────────────────────────────
+
+# Distinct hues for indexing reasoning vs answer boxes
+PALETTE = [
+    (0.90, 0.30, 0.30),   # red
+    (0.30, 0.55, 0.85),   # blue
+    (0.95, 0.70, 0.20),   # amber
+    (0.40, 0.75, 0.40),   # green
+    (0.70, 0.40, 0.85),   # purple
+    (0.25, 0.75, 0.75),   # teal
+    (0.95, 0.55, 0.30),   # orange
+    (0.55, 0.55, 0.55),   # gray
+]
+
+
+def iou_colour(iou: float) -> Tuple[float, float, float]:
+    """Green (good) → red (bad) interpolation around the 0.5 hit threshold."""
+    if iou >= 0.5:
+        return (0.20, 0.75, 0.20)
+    if iou >= 0.25:
+        return (0.95, 0.65, 0.20)
+    return (0.85, 0.20, 0.20)
+
+
+# ───────────────── prediction text cleaning + rendering ──────────────────
+
+_TAG_PATTERN = re.compile(r"<\|im_end\|>|<obj\d+>\s*")
+_BBOX_INLINE_PATTERN = re.compile(r"\[\s*\d[\d\s,.\-]*\d\s*\]")
+
+
+def clean_text(text: str) -> str:
+    text = _TAG_PATTERN.sub("", text)
+    return text.strip()
+
+
+def render_text_panel(ax, raw_text: str, title: str, fontsize: int = 9):
+    """
+    Draw `raw_text` into the given matplotlib axes, highlighting any inline
+    `[a, b, c, d]` bbox literals so the reader can spot them at a glance.
+    """
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.axis("off")
+    ax.set_title(title, fontweight="bold", fontsize=fontsize + 2, loc="left", pad=4)
+    text = clean_text(raw_text) or "(empty)"
+
+    # word-wrap by character count (matplotlib doesn't word-wrap automatically inside transAxes)
+    MAX_CHARS = 110
+    parts = _BBOX_INLINE_PATTERN.split(text)
+    bbox_tokens = _BBOX_INLINE_PATTERN.findall(text)
+
+    # Re-stitch into (string, is_bbox) runs
+    runs: List[Tuple[str, bool]] = []
+    for i, p in enumerate(parts):
+        if p:
+            runs.append((p, False))
+        if i < len(bbox_tokens):
+            runs.append((bbox_tokens[i], True))
+
+    # Tokenise into words / spaces / newlines
+    tokens: List[Tuple[str, bool]] = []  # (text, is_bbox)
+    for run_str, is_bbox in runs:
+        if is_bbox:
+            tokens.append((run_str, True))
+        else:
+            for line_idx, line in enumerate(run_str.split("\n")):
+                if line_idx > 0:
+                    tokens.append(("\n", False))
+                for word_idx, word in enumerate(line.split(" ")):
+                    if word_idx > 0:
+                        tokens.append((" ", False))
+                    if word:
+                        tokens.append((word, False))
+
+    # Pack into display lines
+    lines: List[List[Tuple[str, bool]]] = []
+    cur: List[Tuple[str, bool]] = []
+    cur_len = 0
+    for tok, is_bbox in tokens:
+        if tok == "\n":
+            lines.append(cur)
+            cur, cur_len = [], 0
+            continue
+        if cur_len + len(tok) > MAX_CHARS and cur_len > 0 and not is_bbox:
+            lines.append(cur)
+            cur, cur_len = [], 0
+            if tok == " ":
+                continue
+        cur.append((tok, is_bbox))
+        cur_len += len(tok)
+    if cur:
+        lines.append(cur)
+
+    # Render
+    fig = ax.get_figure()
+    ax_pos = ax.get_position()
+    ax_w_in = ax_pos.width * fig.get_figwidth()
+    char_w_in = fontsize * 0.6 / 72.0
+    char_frac = (char_w_in / ax_w_in) if ax_w_in > 0 else 0.008
+
+    n = max(len(lines), 1)
+    line_h = min(0.07, 0.96 / n)
+    x0, y0 = 0.01, 0.96
+    for li, line_tokens in enumerate(lines):
+        y = y0 - li * line_h
+        if y < 0.02:
+            ax.text(x0, 0.01, "…", transform=ax.transAxes,
+                    fontsize=fontsize, color="gray", va="bottom")
+            break
+        x = x0
+        for tok, is_bbox in line_tokens:
+            if not tok:
+                continue
+            w = len(tok) * char_frac
+            if is_bbox:
+                ax.text(x, y, tok, transform=ax.transAxes, fontsize=fontsize,
+                        va="top", ha="left", fontfamily="monospace",
+                        fontweight="bold", color=(0.10, 0.30, 0.55),
+                        bbox=dict(facecolor=(0.85, 0.92, 1.0),
+                                  edgecolor=(0.30, 0.55, 0.85),
+                                  boxstyle="round,pad=0.15", linewidth=1.0))
+            else:
+                ax.text(x, y, tok, transform=ax.transAxes, fontsize=fontsize,
+                        va="top", ha="left", fontfamily="monospace", color="black")
+            x += w
+
+
+# ───────────────────── bbox + mask drawing helpers ───────────────────────
+
+def overlay_mask(rgb: np.ndarray, mask: np.ndarray, color: Tuple[float, float, float],
+                 alpha: float = 0.45) -> np.ndarray:
+    """Tint mask region of `rgb` (uint8 HxWx3) with `color` (0-1)."""
+    if mask.sum() == 0:
+        return rgb
+    out = rgb.astype(np.float32)
+    cm = np.array(color, dtype=np.float32) * 255.0
+    m = mask.astype(bool)
+    out[m] = out[m] * (1 - alpha) + cm * alpha
+    return np.clip(out, 0, 255).astype(np.uint8)
+
+
+def draw_boxes(ax, boxes: List[List[int]], colors: List[Tuple[float, float, float]],
+               labels: List[str], linewidth: float = 2.5):
+    for box, color, label in zip(boxes, colors, labels):
+        x1, y1, x2, y2 = box
+        rect = Rectangle((x1, y1), max(1, x2 - x1), max(1, y2 - y1),
+                         linewidth=linewidth, edgecolor=color, facecolor="none")
+        ax.add_patch(rect)
+        if label:
+            ax.text(x1 + 2, max(2, y1 - 4), label, fontsize=8, color="white",
+                    bbox=dict(facecolor=color, edgecolor="none",
+                              boxstyle="round,pad=0.15"))
+
+
+# ─────────────────────────── per-sample render ───────────────────────────
+
+def _gt_masks_for_record(rec: Dict, dataset_sample: Dict
+                         ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+    """Extract GT reasoning + answer masks from either the record (RLE)
+    or fall back to the dataset sample's objects_info."""
+    gt = rec["ground_truth"]
+    if gt.get("reasoning_masks_rle") or gt.get("answer_masks_rle"):
+        r = [mask_utils.decode(rle).astype(bool) for rle in gt.get("reasoning_masks_rle", [])]
+        a = [mask_utils.decode(rle).astype(bool) for rle in gt.get("answer_masks_rle", [])]
+        return r, a
+    objects_info = dataset_sample.get("objects_info", {})
+    r = [objects_info[i]["mask"].astype(bool)
+         for i in gt.get("reasoning_obj_ids", []) if i in objects_info]
+    a = [objects_info[i]["mask"].astype(bool)
+         for i in gt.get("answer_obj_ids", []) if i in objects_info]
+    return r, a
+
+
+def render_sample(sample_record: Dict, dataset_sample: Dict, save_path: str):
+    image: Image.Image = dataset_sample["image"]
+
+    pred_r = sample_record["prediction"]["reasoning_bboxes"]
+    pred_a = sample_record["prediction"]["answer_bboxes"]
+    gt_r_ids = sample_record["ground_truth"]["reasoning_obj_ids"]
+    gt_a_ids = sample_record["ground_truth"]["answer_obj_ids"]
+    # Prefer mask IoU; fall back to box IoU when SAM2 phase was skipped.
+    ev = sample_record.get("evaluation", {}) or {}
+    r_ious = ev.get("reasoning_ious") or []
+    a_ious = ev.get("answer_ious") or []
+    r_miou = ev.get("reasoning_miou", 0.0)
+    a_miou = ev.get("answer_miou", 0.0)
+    iou_kind = "mask"
+    if not r_ious and not a_ious:
+        ev_b = sample_record.get("evaluation_bbox", {}) or {}
+        r_ious = ev_b.get("reasoning_ious") or []
+        a_ious = ev_b.get("answer_ious") or []
+        r_miou = ev_b.get("reasoning_miou", 0.0)
+        a_miou = ev_b.get("answer_miou", 0.0)
+        iou_kind = "box"
+    gt_r_masks, gt_a_masks = _gt_masks_for_record(sample_record, dataset_sample)
+
+    img_np = np.array(image.convert("RGB"))
+
+    # Right-side composite: original image with GT masks tinted on top.
+    # Reasoning masks each get a distinct palette colour; answer mask is blue.
+    gt_overlay = img_np.copy()
+    for i, m in enumerate(gt_r_masks):
+        gt_overlay = overlay_mask(gt_overlay, m, PALETTE[i % len(PALETTE)], alpha=0.45)
+    for m in gt_a_masks:
+        gt_overlay = overlay_mask(gt_overlay, m, (0.10, 0.55, 0.95), alpha=0.55)
+
+    fig = plt.figure(figsize=(18, 14))
+    fig.suptitle(
+        f"{sample_record['sample_info']['key']}   "
+        f"R-mIoU={r_miou:.3f}   A-mIoU={a_miou:.3f}   ({iou_kind})",
+        fontsize=14, fontweight="bold", y=0.995,
+    )
+    fig.text(0.5, 0.965,
+             f"Q: {sample_record['sample_info']['question']}",
+             ha="center", va="top", fontsize=10, wrap=True,
+             bbox=dict(boxstyle="round,pad=0.4", facecolor="lightblue", alpha=0.7))
+
+    gs = fig.add_gridspec(2, 2, height_ratios=[5, 3],
+                          top=0.94, bottom=0.01, left=0.02, right=0.99,
+                          hspace=0.10, wspace=0.05)
+
+    # ── Top-left: Prediction (boxes only) ──────────────────────────────
+    ax_p = fig.add_subplot(gs[0, 0])
+    ax_p.imshow(img_np)
+    ax_p.set_title("Prediction (boxes)", fontweight="bold", fontsize=12)
+    ax_p.axis("off")
+    # Per-pred IoU is *best vs any GT mask* (display only — actual scoring
+    # uses Hungarian matching of SAM2-derived pred masks vs GT masks).
+    def _box_mask_iou(box, m):
+        x1, y1, x2, y2 = box
+        h, w = m.shape
+        x1 = max(0, min(int(x1), w - 1)); x2 = max(0, min(int(x2), w))
+        y1 = max(0, min(int(y1), h - 1)); y2 = max(0, min(int(y2), h))
+        if x2 <= x1 or y2 <= y1:
+            return 0.0
+        inter = m[y1:y2, x1:x2].sum()
+        union = m.sum() + (x2 - x1) * (y2 - y1) - inter
+        return float(inter) / float(union) if union > 0 else 0.0
+
+    def _best(boxes, masks):
+        return [max((_box_mask_iou(b, m) for m in masks), default=0.0) for b in boxes]
+
+    p_r_best = _best(pred_r, gt_r_masks)
+    p_a_best = _best(pred_a, gt_a_masks)
+    draw_boxes(ax_p, pred_r,
+               [iou_colour(v) for v in p_r_best],
+               [f"R{i+1} IoU={v:.2f}" for i, v in enumerate(p_r_best)])
+    draw_boxes(ax_p, pred_a,
+               [iou_colour(v) for v in p_a_best],
+               [f"A{i+1} IoU={v:.2f}" for i, v in enumerate(p_a_best)],
+               linewidth=3.5)
+
+    # ── Top-right: Ground Truth (masks only) ───────────────────────────
+    ax_g = fig.add_subplot(gs[0, 1])
+    ax_g.imshow(gt_overlay)
+    ax_g.set_title("Ground Truth (masks)", fontweight="bold", fontsize=12)
+    ax_g.axis("off")
+    # Tiny per-mask centroid label so reader can match GT mask → IoU score.
+    for i, m in enumerate(gt_r_masks):
+        if m.any():
+            ys, xs = np.nonzero(m)
+            cx, cy = int(xs.mean()), int(ys.mean())
+            iou = r_ious[i] if i < len(r_ious) else 0.0
+            ax_g.text(cx, cy, f"R{i+1} obj{gt_r_ids[i]}\nIoU={iou:.2f}",
+                       fontsize=8, color="white", ha="center", va="center",
+                       bbox=dict(facecolor=PALETTE[i % len(PALETTE)],
+                                 edgecolor="none", boxstyle="round,pad=0.2", alpha=0.85))
+    for i, m in enumerate(gt_a_masks):
+        if m.any():
+            ys, xs = np.nonzero(m)
+            cx, cy = int(xs.mean()), int(ys.mean())
+            iou = a_ious[i] if i < len(a_ious) else 0.0
+            ax_g.text(cx, cy, f"A obj{gt_a_ids[i]}\nIoU={iou:.2f}",
+                       fontsize=9, color="white", ha="center", va="center",
+                       bbox=dict(facecolor=(0.10, 0.55, 0.95),
+                                 edgecolor="none", boxstyle="round,pad=0.2", alpha=0.9))
+
+    # ── Bottom: text panels ─────────────────────────────────────────────
+    ax_think = fig.add_subplot(gs[1, 0])
+    ax_think.set_facecolor("#f9f9f9")
+    text = sample_record["prediction"]["text"] or ""
+    think_match = re.search(r"<think>(.*?)</think>", text, re.DOTALL)
+    answer_match = re.search(r"<answer>(.*?)</answer>", text, re.DOTALL)
+    think_str = think_match.group(1) if think_match else (
+        text.split("<answer>")[0] if "<answer>" in text else text)
+    answer_str = answer_match.group(1) if answer_match else (
+        text.split("</think>")[-1] if "</think>" in text else "")
+    render_text_panel(ax_think, think_str, "<think>", fontsize=9)
+
+    ax_ans = fig.add_subplot(gs[1, 1])
+    ax_ans.set_facecolor("#f0f8ff")
+    render_text_panel(ax_ans, answer_str, "<answer>", fontsize=9)
+
+    plt.savefig(save_path, dpi=150, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+
+# ─────────────────────────────── driver ──────────────────────────────────
+
+def visualize(results_dir: str, packed_tfrecord: str,
+              low_iou_only: bool = False,
+              max_samples: Optional[int] = None) -> None:
+    # Try the mask-eval filename, then the older bbox one, then the
+    # summary file's `detailed_results` key.
+    candidates = [
+        ("ver_results.json", None),
+        ("ver_bbox_results.json", None),
+        ("ver_summary.json", "detailed_results"),
+        ("ver_bbox_summary.json", "detailed_results"),
+    ]
+    results = None
+    for fname, sub in candidates:
+        path = os.path.join(results_dir, fname)
+        if os.path.isfile(path):
+            with open(path) as f:
+                data = json.load(f)
+            results = data if sub is None else data.get(sub, [])
+            print(f"[viz] loaded {len(results)} records from {path}")
+            break
+    if results is None:
+        raise FileNotFoundError(
+            f"No ver_results.json / ver_bbox_results.json found under {results_dir}")
+
+    print(f"[viz] {len(results)} sample records loaded from {results_dir}")
+
+    out_dir = os.path.join(results_dir, "visualizations")
+    os.makedirs(out_dir, exist_ok=True)
+
+    print(f"[viz] loading packed dataset: {packed_tfrecord}")
+    dataset = PackedVRTEvalDataset(packed_tfrecord)
+
+    # Sort for stable output ordering
+    results = sorted(results, key=lambda r: r["sample_info"]["key"])
+
+    rendered = 0
+    for rec in results:
+        if max_samples is not None and rendered >= max_samples:
+            break
+        if low_iou_only:
+            mean_iou = (rec["evaluation"]["reasoning_miou"]
+                        + rec["evaluation"]["answer_miou"]) / 2.0
+            if mean_iou >= 0.5:
+                continue
+
+        key = rec["sample_info"]["key"]
+        ds_sample = dataset.get_sample(key)
+        if ds_sample is None:
+            print(f"[viz][warn] dataset miss for {key}, skipping")
+            continue
+
+        out_path = os.path.join(out_dir, f"{key}.png")
+        try:
+            render_sample(rec, ds_sample, out_path)
+            rendered += 1
+        except Exception as e:  # noqa: BLE001
+            print(f"[viz][warn] {key} render failed: {e!r}")
+
+    print(f"[viz] {rendered} visualisations written to {out_dir}")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Visualise OpenRouter VER bbox eval results.")
+    p.add_argument("results_dir",
+                   help="Eval output dir (containing ver_bbox_results.json).")
+    p.add_argument("--packed_tfrecord",
+                   default=os.path.join(PROJECT_ROOT, "data/VRT-Eval/vrt_eval.tfrecord"),
+                   help="Path to packed VRT eval TFRecord.")
+    p.add_argument("--low-iou-only", action="store_true",
+                   help="Only render samples whose mean IoU < 0.5.")
+    p.add_argument("--max_samples", type=int, default=None,
+                   help="Cap number of samples rendered (debug).")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    visualize(args.results_dir, args.packed_tfrecord,
+              low_iou_only=args.low_iou_only,
+              max_samples=args.max_samples)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
projects/vrt_sa2va/eval_openrouter/ ships a self-contained pipeline to evaluate the VRT-Eval benchmark on closed-source vision LLMs (Gemini, GPT, OpenRouter-hosted Qwen, etc.):

  1. Inference  — parallel HTTP via OpenRouter, returning bounding boxes.
  2. SAM2 phase — predicted boxes are turned into masks by SAM2.
  3. Scoring    — masks are matched against the human-labelled GT in
                  HarborYuan/VRT-Eval via Hungarian assignment on IoU,
                  reporting mIoU / LQ / SQ for both reasoning and answer.

Files:
- eval_openrouter.py    main entry point
- common.py             box parsing, SAM2 wrapper, scoring helpers
- visualize_results.py  optional --visualize side-by-side renderer