### PR TITLE
Fix SAMTok mixed-precision dtype mismatches

### DIFF
--- a/projects/samtok/models/sam2.py
+++ b/projects/samtok/models/sam2.py
@@ -482,6 +482,7 @@ class PositionEmbeddingRandom(nn.Module):
         """Positionally encode points that are normalized to [0,1]."""
         # assuming coords are in [0, 1]^2 square and have d_1 x ... x d_n x 2 shape
         coords = 2 * coords - 1
+        coords = coords.to(self.positional_encoding_gaussian_matrix.dtype)
         coords = coords @ self.positional_encoding_gaussian_matrix
         coords = 2 * np.pi * coords
         # outputs d_1 x ... x d_n x C shape
@@ -3830,6 +3831,7 @@ class VQEmebedding(nn.Embedding):
         assert inputs_shape[-1] == embed_dim
 
         inputs_flat = inputs.reshape(-1, embed_dim).contiguous()
+        codebook_t = codebook_t.to(inputs_flat.dtype)
 
         inputs_norm_sq = inputs_flat.pow(2.).sum(dim=1, keepdim=True)
         codebook_t_norm_sq = codebook_t.pow(2.).sum(dim=0, keepdim=True)
@@ -4179,6 +4181,7 @@ class VQ_SAM2(PreTrainedModel):
             gt_masks = [F.interpolate(gt_mask.unsqueeze(0).to(pred_masks.dtype), size=pred_masks[0].shape[-2:], mode='nearest').squeeze(0) for gt_mask in gt_masks]
             gt_masks = torch.cat(gt_masks, dim=0)
             pred_masks = pred_masks.flatten(0, 1)
+            loss = quant_loss * self.config.vq_loss_weight
 
             if self.config.loss_sample_points:
                 sampled_pred_mask, sampled_gt_mask = self.sample_points(pred_masks, gt_masks)


### PR DESCRIPTION
## Problem

SAMTok tokenizer training can mix FP32 and BF16 tensors inside positional encoding and vector-quantizer distance calculation. The resulting matrix operations require matching operand dtypes and can fail during xTuner AMP training. The aggregate model output also uses `loss` before initialization, while the commitment loss is returned separately.

## Solution

- Cast normalized point coordinates to the positional-encoding buffer dtype before matrix multiplication.
- Cast the codebook view to the flattened input dtype before computing norms and `torch.addmm`.
- Initialize the aggregate loss with the configured weighted commitment loss before adding reconstruction losses.

This keeps the existing AMP configuration and model interfaces unchanged; it only aligns operands at the operations that require it.

## Validation

- `git diff --check`
- Compiled `projects/samtok/models/sam2.py` with Python's `compile()`.
- Ran focused CPU checks against the actual patched methods for FP32/BF16 inputs in both directions, including comparison of quantizer distances with an FP32 `torch.cdist` reference.
- Ran focused CUDA checks against the actual patched methods for both FP32-input/BF16-weight and BF16-input/FP32-weight combinations.

A full tokenizer training run was not performed because it requires the full xTuner/mmengine environment and SA1B training data.

Fixes #134