### PR TITLE
Fix SaSaSa2VA evaluation CLI defaults

### DIFF
--- a/projects/sasasa2va/evaluation/ref_vos_eval.py
+++ b/projects/sasasa2va/evaluation/ref_vos_eval.py
@@ -61,6 +61,14 @@ DATASETS_INFO = {
     },
 }
 
+INFERENCE_MODES = [
+    'uniform',
+    'uniform_plus',
+    'q_frame',
+    'wrap_around',
+    'wrap_around_plus',
+]
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description='RefVOS')
@@ -77,9 +85,11 @@ def parse_args():
         help='job launcher')
     parser.add_argument('--local_rank', '--local-rank', type=int, default=0)
     parser.add_argument('--submit', action='store_true')
-    parser.add_argument('--mode', type=str, default='default')
+    parser.add_argument(
+        '--mode', choices=INFERENCE_MODES, default='uniform')
     parser.add_argument('--print_answer', action='store_true', default=False)
-    parser.add_argument('--work_dir', type=str, default=None)
+    parser.add_argument(
+        '--work-dir', '--work_dir', dest='work_dir', type=str, default=None)
     parser.add_argument('--deepspeed', type=str, default=None) # dummy
     parser.add_argument('--samurai', action='store_true', default=False)
     

--- a/tests/test_sasasa2va_eval_cli.py
+++ b/tests/test_sasasa2va_eval_cli.py
@@ -1,0 +1,66 @@
+import argparse
+import ast
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+EVALUATOR = (
+    Path(__file__).parents[1]
+    / 'projects'
+    / 'sasasa2va'
+    / 'evaluation'
+    / 'ref_vos_eval.py'
+)
+
+
+def load_argument_parser():
+    """Load only the evaluator's dependency-free argument parsing code."""
+    source = EVALUATOR.read_text(encoding='utf-8')
+    tree = ast.parse(source, filename=str(EVALUATOR))
+    selected = [
+        node for node in tree.body
+        if (isinstance(node, (ast.Assign, ast.FunctionDef))
+            and (not isinstance(node, ast.Assign)
+                 or any(isinstance(target, ast.Name)
+                        and target.id in {'DATASETS_INFO', 'INFERENCE_MODES'}
+                        for target in node.targets))
+            and (not isinstance(node, ast.FunctionDef)
+                 or node.name == 'parse_args'))
+    ]
+    namespace = {'argparse': argparse, 'os': os}
+    exec(compile(ast.Module(selected, type_ignores=[]), str(EVALUATOR), 'exec'),
+         namespace)
+    return namespace['parse_args']
+
+
+class SaSaSa2VAEvalCliTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.parse_args = staticmethod(load_argument_parser())
+
+    def parse(self, *arguments):
+        with patch.object(sys, 'argv', ['ref_vos_eval.py', *arguments]):
+            return self.parse_args()
+
+    def test_documented_work_dir_and_default_mode(self):
+        args = self.parse('model', '--work-dir', 'outputs')
+
+        self.assertEqual(args.work_dir, 'outputs')
+        self.assertEqual(args.mode, 'uniform')
+
+    def test_underscored_work_dir_remains_supported(self):
+        args = self.parse('model', '--work_dir', 'outputs')
+
+        self.assertEqual(args.work_dir, 'outputs')
+
+    def test_invalid_mode_is_rejected_by_argument_parser(self):
+        with self.assertRaises(SystemExit):
+            self.parse('model', '--mode', 'default')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- use the documented `uniform` inference mode as the evaluator default
- accept both `--work-dir` and the existing `--work_dir` spelling
- reject unsupported modes during argument parsing
- add focused regression coverage for the documented command and compatibility alias

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sasasa2va_eval_cli.py' -v`
- parsed both changed Python files with `ast.parse`
- `git diff --check`

Fixes #152