### PR TITLE
Fix checkpoint conversion commands in project READMEs

### DIFF
--- a/projects/sa2va/README.md
+++ b/projects/sa2va/README.md
@@ -235,7 +235,7 @@ For other types of data, you may need to customize the dataloader and configurat
 
 Please run the following script to convert:
 ```bash
-python tools/convert_to_hf.py projects/sa2va/configs/sa2va_in30_8b.py --pth-model PATH_TO_PTH_MODEL --save-path PATH_TO_SAVE_FOLDER
+python tools/convert_to_hf.py projects/sa2va/configs/sa2va_in30_8b.py PATH_TO_PTH_MODEL --save-path PATH_TO_SAVE_FOLDER
 ```
 </details>
 

--- a/projects/sasasa2va/README.md
+++ b/projects/sasasa2va/README.md
@@ -55,7 +55,7 @@ bash tools/dist.sh train projects/sasasa2va/configs/YOUR_CONFIG NUM_GPUS
 
 Then run the following command to convert pth model to Huggingface format model:
 ```bash
-python projects/sasasa2va/hf/convert_to_hf.py projects/sasasa2va/configs/YOUR_CONFIG --pth-model PATH_TO_PTH_MODEL --save-path PATH_TO_HF_MODEL
+python projects/sasasa2va/hf/convert_to_hf.py projects/sasasa2va/configs/YOUR_CONFIG PATH_TO_PTH_MODEL --save-path PATH_TO_HF_MODEL
 ```
 
 ### Evaluation


### PR DESCRIPTION
## Summary

- pass `pth_model` as the required positional argument in the Sa2VA conversion example
- apply the same correction to the SaSaSa2VA conversion example

## Validation

- ran a Python AST/documentation consistency check confirming both converters declare positional `config` and `pth_model` arguments and both README commands use that order
- `git diff --check`

Fixes #153