### PR TITLE
Fix Sa2VA QA evaluation entry-point paths

### DIFF
--- a/projects/sa2va/README.md
+++ b/projects/sa2va/README.md
@@ -265,12 +265,12 @@ We use [sa2va_eval](https://github.com/zhang-tao-whu/sa2va_eval) (a modified ver
 
 **Single-GPU Evaluation Example:**
 ```bash
-python run.py --data MMBench_DEV_EN MME SEEDBench_IMG --model Sa2VA-1B --verbose
+python sa2va_eval/run.py --data MMBench_DEV_EN MME SEEDBench_IMG --model Sa2VA-1B --verbose
 ```
 
 **Multi-GPU Evaluation Example:**
 ```bash
-torchrun --nproc-per-node=8 run.py --data MMBench_DEV_EN SEEDBench_IMG MMStar AI2D_TEST MMMU_DEV_VAL ScienceQA_TEST --model Sa2VA-4B Sa2VA-8B --verbose
+torchrun --nproc-per-node=8 sa2va_eval/run.py --data MMBench_DEV_EN SEEDBench_IMG MMStar AI2D_TEST MMMU_DEV_VAL ScienceQA_TEST --model Sa2VA-4B Sa2VA-8B --verbose
 ```
 </details>
 


### PR DESCRIPTION
## Summary

- point the single-GPU QA evaluation example to the tracked `sa2va_eval/run.py` entry point
- make the same correction in the multi-GPU torchrun example

## Validation

- ran a Python documentation/path check confirming both QA commands reference `sa2va_eval/run.py` and that the tracked entry point exists
- parsed `sa2va_eval/run.py` with `ast.parse`
- `git diff --check`

Fixes #154