### PR TITLE
Propagate failures from the evaluation batch wrapper

### DIFF
--- a/projects/sa2va/evaluation/run_all_evals.py
+++ b/projects/sa2va/evaluation/run_all_evals.py
@@ -74,8 +74,10 @@ def main():
 
     except subprocess.CalledProcessError as e:
         print(f"\nAn error occurred during evaluation: {e}")
+        raise
     except Exception as e:
         print(f"\nAn unexpected error occurred: {e}")
+        raise
 
 if __name__ == "__main__":
     main()

--- a/tests/test_run_all_evals.py
+++ b/tests/test_run_all_evals.py
@@ -1,0 +1,41 @@
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / 'projects'
+    / 'sa2va'
+    / 'evaluation'
+    / 'run_all_evals.py'
+)
+
+
+def load_script():
+    spec = importlib.util.spec_from_file_location('run_all_evals_under_test',
+                                                   SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RunAllEvalsFailureStatusTest(unittest.TestCase):
+
+    def test_subprocess_failure_is_propagated(self):
+        module = load_script()
+        failure = subprocess.CalledProcessError(7, ['evaluation'])
+
+        with patch.object(sys, 'argv', ['run_all_evals.py', 'model']), \
+                patch.object(module, 'run_command', side_effect=failure):
+            with self.assertRaises(subprocess.CalledProcessError) as context:
+                module.main()
+
+        self.assertEqual(context.exception.returncode, 7)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- retain the current contextual error messages from the evaluation batch wrapper
- re-raise subprocess and unexpected failures so callers receive a nonzero exit status
- add a regression test that injects a subprocess failure and verifies it propagates

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_run_all_evals.py' -v`
- parsed both changed Python files with `ast.parse`
- `git diff --check`

Fixes #160