### PR TITLE
Fix the PerceptionLM GCG fallback result

### DIFF
--- a/projects/samtok/evaluation/perceptionlm/plm_gcg_eval.py
+++ b/projects/samtok/evaluation/perceptionlm/plm_gcg_eval.py
@@ -263,7 +263,7 @@ def main():
                 '',
                 prediction['prediction_masks']
             )
-            results.append(output_text[0])
+            results.append('')
             continue
         generate_ids = model.generate(**inputs, max_new_tokens=256)
         input_length = inputs["input_ids"].shape[1]

--- a/tests/test_perceptionlm_gcg_fallback.py
+++ b/tests/test_perceptionlm_gcg_fallback.py
@@ -1,0 +1,44 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / 'projects'
+    / 'samtok'
+    / 'evaluation'
+    / 'perceptionlm'
+    / 'plm_gcg_eval.py'
+)
+
+
+class PerceptionLMFallbackTest(unittest.TestCase):
+
+    def test_device_transfer_fallback_appends_empty_text(self):
+        tree = ast.parse(SCRIPT.read_text(encoding='utf-8'),
+                         filename=str(SCRIPT))
+        main = next(
+            node for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == 'main')
+        transfer_handler = next(
+            handler for handler in ast.walk(main)
+            if isinstance(handler, ast.ExceptHandler)
+            and any(isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == 'process_and_save_output'
+                    for node in ast.walk(handler)))
+        appended_values = [
+            call.args[0].value for call in ast.walk(transfer_handler)
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == 'append'
+            and call.args
+            and isinstance(call.args[0], ast.Constant)
+        ]
+
+        self.assertEqual(appended_values, [''])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- append the explicit empty text produced by the device-transfer fallback
- avoid referencing generation output before generation has run
- add a focused source regression test for the fallback result

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_perceptionlm_gcg_fallback.py' -v`
- `python -m ruff check --select F821 projects/samtok/evaluation/perceptionlm/plm_gcg_eval.py tests/test_perceptionlm_gcg_fallback.py`
- `git diff --check`

Fixes #164