### PR TITLE
Fix MMLongBench unit suffix normalization

### DIFF
--- a/sa2va_eval/vlmeval/dataset/mmlongbench.py
+++ b/sa2va_eval/vlmeval/dataset/mmlongbench.py
@@ -141,12 +141,11 @@ def is_float_equal(reference, prediction, include_percentage: bool = False, is_c
 
 def get_clean_string(s):
     s = str(s).lower().strip()
-    if s.endswith('mile'):
-        s.rstrip('mile').strip()
-    if s.endswith('miles'):
-        s.rstrip('miles').strip()
-    if s.endswith('million'):
-        s.rstrip('million').strip()
+    for suffix in ('miles', 'mile', 'million'):
+        unit = f' {suffix}'
+        if s.endswith(unit):
+            s = s[:-len(unit)].strip()
+            break
     # remove parenthesis
     s = re.sub(r'\s*\([^)]*\)', '', s).strip()
     # remove quotes

--- a/tests/test_mmlongbench_clean_string.py
+++ b/tests/test_mmlongbench_clean_string.py
@@ -1,0 +1,44 @@
+import ast
+import re
+import unittest
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / 'sa2va_eval'
+    / 'vlmeval'
+    / 'dataset'
+    / 'mmlongbench.py'
+)
+
+
+def load_get_clean_string():
+    tree = ast.parse(SCRIPT.read_text(encoding='utf-8'), filename=str(SCRIPT))
+    function = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == 'get_clean_string')
+    namespace = {'re': re}
+    exec(compile(ast.Module([function], type_ignores=[]), str(SCRIPT), 'exec'),
+         namespace)
+    return namespace['get_clean_string']
+
+
+class MMLongBenchCleanStringTest(unittest.TestCase):
+
+    def test_removes_exact_numeric_suffixes(self):
+        clean = load_get_clean_string()
+
+        self.assertEqual(clean('12 miles'), '12')
+        self.assertEqual(clean('5 mile'), '5')
+        self.assertEqual(clean('10 million'), '10')
+
+    def test_does_not_strip_suffix_characters_from_other_words(self):
+        clean = load_get_clean_string()
+
+        self.assertEqual(clean('smiles'), 'smiles')
+        self.assertEqual(clean('profile'), 'profile')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- assign the normalized MMLongBench answer after removing supported unit suffixes
- remove exact space-delimited suffixes instead of treating suffix text as a character set
- retain Python 3.7 syntax compatibility
- add regression cases for mile, miles, million, and unrelated words

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_mmlongbench_clean_string.py' -v`
- parsed the changed files with Python 3.7 grammar via `ast.parse(..., feature_version=(3, 7))`
- `git diff --check`

Fixes #166